### PR TITLE
switch auth from cookies to bearer tokens

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_API_URL=https://personal-website-backend-fvac.onrender.com

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # overview
 
 frontend for a personal website
+
 - backend: @seanboose/personal-website-backend
 - shared types: @seanboose/personal-website-api-types
 
 built using create-vite with react-router-v7 option
+
 - goal is to get more practice with SSR components
 
 uses JWT for authentication with backend
 
-deployed to https://personal-website-frontend-flame.vercel.app/image-display
+# deployment urls
+
+- production: https://personal-website-frontend-flame.vercel.app/image-display
+- staging: https://personal-website-frontend-staging.vercel.app/image-display
 
 # roadmap
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,26 @@
 
 frontend for a personal website
 
-- backend: @seanboose/personal-website-backend
-- shared types: @seanboose/personal-website-api-types
+built using create-vite with react-router-v7 option (i want to get more practice with SSR apps)
 
-built using create-vite with react-router-v7 option
+uses Bearer token authorization (JWT) to communicate with backend
 
-- goal is to get more practice with SSR components
+# deployment
 
-uses JWT for authentication with backend
+automatically deploys to vercel on changes.
+any changes to the `production` branch deploys to production, any changes on any other branch deploy to `staging`.
+id like it to just deploy on changes to the `staging` branch, but vercel does not currently support that on their free
+tier.
 
-# deployment urls
+urls
 
 - production: https://personal-website-frontend-production.vercel.app/image-display
 - staging: https://personal-website-frontend-staging.vercel.app/image-display
+
+# related repos
+
+- backend: @seanboose/personal-website-backend
+- shared types: @seanboose/personal-website-api-types
 
 # roadmap
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ uses Bearer token authorization (JWT) to communicate with backend
 # deployment
 
 automatically deploys to vercel on changes.
-any changes to the `production` branch deploys to production, any changes on any other branch deploy to `staging`.
-id like it to just deploy on changes to the `staging` branch, but vercel does not currently support that on their free
-tier.
+any changes to the `production` branch deploys to production.
+any changes to other branches deploy to preview instances.
 
 urls
 
 - production: https://personal-website-frontend-production.vercel.app/image-display
 - staging: https://personal-website-frontend-staging.vercel.app/image-display
+- <anyBranch>: https://personal-website-frontend-<anyBranch>.vercel.app/image-display
 
 # related repos
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ uses JWT for authentication with backend
 
 # deployment urls
 
-- production: https://personal-website-frontend-flame.vercel.app/image-display
+- production: https://personal-website-frontend-production.vercel.app/image-display
 - staging: https://personal-website-frontend-staging.vercel.app/image-display
 
 # roadmap

--- a/app/image-display/imageDisplay.tsx
+++ b/app/image-display/imageDisplay.tsx
@@ -17,12 +17,8 @@ interface LoaderResponse {
 }
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  console.log('LOADER: start');
   const { body, headers } = await requestWithAuth(request, api.images.list);
   const { images = [] } = body;
-
-  // TODO this considers data to be `any` still, need to figure that out
-  console.log('LOADER: returning');
   return data({ images } satisfies LoaderResponse, { headers });
 };
 
@@ -31,7 +27,6 @@ interface ActionResponse extends LoaderResponse {
 }
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  console.log('ACTION: start');
   let loadCount = 0;
   const formData = await request.formData();
   const rawLoadCount = formData.get('loadCount');
@@ -41,10 +36,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const { body, headers } = await requestWithAuth(request, api.images.list);
   const { images = [] } = body;
-  console.log('ACTION: returning');
 
-  // TODO id like a better typing solution for this response than a `satisfies`, but it may not be possible
-  // TS infers types fine, but i want guard rails that prevent me from changing the response on accident
   return data({ images, loadCount } satisfies ActionResponse, { headers });
 };
 

--- a/app/image-display/imageDisplay.tsx
+++ b/app/image-display/imageDisplay.tsx
@@ -18,11 +18,8 @@ interface LoaderResponse {
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   console.log('LOADER: start');
-  const { data: dataResponse, headers } = await requestWithAuth(
-    request,
-    api.images.list,
-  );
-  const { images = [] }: LoaderResponse = dataResponse;
+  const { body, headers } = await requestWithAuth(request, api.images.list);
+  const { images = [] } = body;
 
   // TODO this considers data to be `any` still, need to figure that out
   console.log('LOADER: returning');
@@ -42,12 +39,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     loadCount = parseInt(rawLoadCount, 10) + 1;
   }
 
-  const { data: dataResponse, headers } = await requestWithAuth(
-    request,
-    api.images.list,
-  );
+  const { body, headers } = await requestWithAuth(request, api.images.list);
+  const { images = [] } = body;
   console.log('ACTION: returning');
-  const { images = [] } = dataResponse;
 
   // TODO id like a better typing solution for this response than a `satisfies`, but it may not be possible
   // TS infers types fine, but i want guard rails that prevent me from changing the response on accident

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -57,7 +57,13 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
       error.status === 404
         ? 'The requested page could not be found.'
         : error.statusText || details;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
+  } else if (error && error instanceof Error) {
+    console.error('ErrorBoundary caught an error:', {
+      message: error.message,
+      stack: error.stack,
+      name: error.name,
+    });
+
     details = error.message;
     stack = error.stack;
   }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,6 +1,8 @@
 import { index, route, type RouteConfig } from '@react-router/dev/routes';
 
+// TODO may want to switch this to automatically get routes from file structure
 export default [
   index('routes/home.tsx'),
   route('image-display', './image-display/imageDisplay.tsx'),
+  route('auth/init', 'routes/auth.init.ts'),
 ] satisfies RouteConfig;

--- a/app/routes/auth.init.ts
+++ b/app/routes/auth.init.ts
@@ -6,11 +6,14 @@ import { fetchGrantAuth, makeAuthCookies } from '~/shared/auth';
 export const loader: LoaderFunction = async ({ request }) => {
   const backendRes = await fetchGrantAuth();
 
-  const { accessToken, refreshToken } = await backendRes.json();
-  const { accessTokenCookie, refreshTokenCookie } = makeAuthCookies(
+  const { accessToken, expiresIn, refreshToken, refreshExpiresIn } =
+    await backendRes.json();
+  const { accessTokenCookie, refreshTokenCookie } = makeAuthCookies({
     accessToken,
+    expiresIn,
     refreshToken,
-  );
+    refreshExpiresIn,
+  });
 
   const url = new URL(request.url);
   const redirectTo = url.searchParams.get('redirectTo') || '/';

--- a/app/routes/auth.init.ts
+++ b/app/routes/auth.init.ts
@@ -1,0 +1,21 @@
+import type { LoaderFunction } from 'react-router';
+import { redirect } from 'react-router';
+
+import { fetchGrantAuth } from '~/shared/auth';
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const backendRes = await fetchGrantAuth();
+
+  const { accessToken, refreshToken } = await backendRes.json();
+  const accessTokenCookie = `access_token=${accessToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${15 * 60}`;
+  const refreshTokenCookie = `refresh_token=${refreshToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${7 * 24 * 60 * 60}`;
+
+  const url = new URL(request.url);
+  const redirectTo = url.searchParams.get('redirectTo') || '/';
+  return redirect(redirectTo, {
+    headers: [
+      ['Set-Cookie', accessTokenCookie],
+      ['Set-Cookie', refreshTokenCookie],
+    ],
+  });
+};

--- a/app/routes/auth.init.ts
+++ b/app/routes/auth.init.ts
@@ -1,14 +1,16 @@
 import type { LoaderFunction } from 'react-router';
 import { redirect } from 'react-router';
 
-import { fetchGrantAuth } from '~/shared/auth';
+import { fetchGrantAuth, makeAuthCookies } from '~/shared/auth';
 
 export const loader: LoaderFunction = async ({ request }) => {
   const backendRes = await fetchGrantAuth();
 
   const { accessToken, refreshToken } = await backendRes.json();
-  const accessTokenCookie = `access_token=${accessToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${15 * 60}`;
-  const refreshTokenCookie = `refresh_token=${refreshToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${7 * 24 * 60 * 60}`;
+  const { accessTokenCookie, refreshTokenCookie } = makeAuthCookies(
+    accessToken,
+    refreshToken,
+  );
 
   const url = new URL(request.url);
   const redirectTo = url.searchParams.get('redirectTo') || '/';

--- a/app/routes/auth.init.ts
+++ b/app/routes/auth.init.ts
@@ -1,20 +1,10 @@
 import type { LoaderFunction } from 'react-router';
 import { redirect } from 'react-router';
 
-import { fetchGrantAuth, makeAuthCookies } from '~/shared/auth';
+import { fetchGrantAuth } from '~/shared/auth';
 
 export const loader: LoaderFunction = async ({ request }) => {
-  const backendRes = await fetchGrantAuth();
-
-  const { accessToken, expiresIn, refreshToken, refreshExpiresIn } =
-    await backendRes.json();
-  const { accessTokenCookie, refreshTokenCookie } = makeAuthCookies({
-    accessToken,
-    expiresIn,
-    refreshToken,
-    refreshExpiresIn,
-  });
-
+  const { accessTokenCookie, refreshTokenCookie } = await fetchGrantAuth();
   const url = new URL(request.url);
   const redirectTo = url.searchParams.get('redirectTo') || '/';
   return redirect(redirectTo, {

--- a/app/shared/api.ts
+++ b/app/shared/api.ts
@@ -1,6 +1,11 @@
-import { clientConfig } from '../shared/config';
+import { type ImageData } from '@seanboose/personal-website-api-types';
 
-const apiFetch = async (path: string, options: RequestInit = {}) => {
+import { clientConfig } from '~/shared/config';
+
+const apiFetch = async <T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> => {
   const headers = {
     ...options.headers,
     'Content-Type': 'application/json',
@@ -18,13 +23,17 @@ const apiFetch = async (path: string, options: RequestInit = {}) => {
       `API request failed with status=${res.status}, message="${message}"`,
     );
   }
-  return res.json();
+  return res.json(); // TODO may need to cast as Promise<T>;
 };
+
+interface ImagesListResponse {
+  images: ImageData[];
+}
 
 export const api = {
   images: {
     list: async (accessToken?: string) =>
-      apiFetch(
+      apiFetch<ImagesListResponse>(
         'images/list',
         accessToken
           ? { headers: { Authorization: `Bearer ${accessToken}` } }

--- a/app/shared/api.ts
+++ b/app/shared/api.ts
@@ -16,16 +16,16 @@ const apiFetch = async <T>(
     headers,
   });
   if (!res.ok) {
-    // TODO idk if i like this pattern. its hard to troubleshoot failures, especially SSR requests
     const json = await res.json();
     const message = json?.message;
     throw new Error(
       `API request failed with status=${res.status}, message="${message}"`,
     );
   }
-  return res.json(); // TODO may need to cast as Promise<T>;
+  return res.json();
 };
 
+// TODO define these with oapi in api-types
 interface ImagesListResponse {
   images: ImageData[];
 }

--- a/app/shared/api.ts
+++ b/app/shared/api.ts
@@ -1,11 +1,9 @@
 import { clientConfig } from '../shared/config';
-import { authCookie } from './auth';
 
 const apiFetch = async (path: string, options: RequestInit = {}) => {
   const headers = {
     ...options.headers,
     'Content-Type': 'application/json',
-    Cookie: authCookie,
   };
   const res = await fetch(`${clientConfig.apiUrl}/api/${path}`, {
     ...options,
@@ -25,6 +23,12 @@ const apiFetch = async (path: string, options: RequestInit = {}) => {
 
 export const api = {
   images: {
-    list: async () => apiFetch('images/list'),
+    list: async (accessToken?: string) =>
+      apiFetch(
+        'images/list',
+        accessToken
+          ? { headers: { Authorization: `Bearer ${accessToken}` } }
+          : undefined,
+      ),
   },
 };

--- a/app/shared/auth.ts
+++ b/app/shared/auth.ts
@@ -11,6 +11,69 @@ const authRequestClient = 'personal-website-frontend';
 const grantAuthUrl = `${clientConfig.apiUrl}/api/auth/grant`;
 const refreshAuthUrl = `${clientConfig.apiUrl}/api/auth/refresh`;
 
+/**
+ * make a request to an api endpoint that requires authentication.
+ *  if there's a valid accessToken: makes the request normally
+ *  if accessToken does not exist or is expired: refreshes auth, then makes original request
+ *  if refreshToken does not exist or is expired: no session exists, redirects to login
+ * you MUST return the headers returned by this function in the calling loader/action in order to keep auth cookies current
+ *
+ * @param request pass in the request from the action/loader to retrieve auth tokens
+ * @param apiCall api request to be performed. must be curried to take only an accessToken
+ * @param accessTokenOverride when making multiple calls in a single action/loader, pass in the accessToken returned by the previous call
+ */
+export async function requestWithAuth<T>(
+  request: Request,
+  apiCall: (accessToken: string) => Promise<T>,
+  accessTokenOverride?: string,
+): Promise<{
+  body: T;
+  headers?: HeadersInit;
+  accessToken: string;
+}> {
+  const accessToken = accessTokenOverride || getAccessTokenFromRequest(request);
+  const refreshToken = getRefreshTokenFromRequest(request);
+  if (!refreshToken) {
+    redirectToLogin(request);
+  }
+
+  if (typeof accessToken !== 'undefined') {
+    try {
+      const body = await apiCall(accessToken);
+      return { body, accessToken };
+    } catch (error) {
+      // TODO really need to create that new error type
+      if (!(error instanceof Error)) {
+        throw error;
+      }
+    }
+  }
+
+  const response = await fetchRefreshAuth(request);
+  const json = await response.json();
+  const {
+    accessToken: newAccessToken,
+    expiresIn,
+    refreshToken: newRefreshToken,
+    refreshExpiresIn,
+  } = json;
+  const { accessTokenCookie, refreshTokenCookie } = makeAuthCookies({
+    accessToken: newAccessToken,
+    expiresIn,
+    refreshToken: newRefreshToken,
+    refreshExpiresIn,
+  });
+  const body = await apiCall(newAccessToken);
+  return {
+    body,
+    headers: [
+      ['Set-Cookie', accessTokenCookie],
+      ['Set-Cookie', refreshTokenCookie],
+    ],
+    accessToken: newAccessToken,
+  };
+}
+
 export const fetchGrantAuth = async () => {
   const res = await fetch(grantAuthUrl, {
     method: 'POST',
@@ -30,10 +93,36 @@ export const fetchGrantAuth = async () => {
     );
   }
 
-  return res;
+  const { accessToken, expiresIn, refreshToken, refreshExpiresIn } =
+    await res.json();
+  const { accessTokenCookie, refreshTokenCookie } = makeAuthCookies({
+    accessToken,
+    expiresIn,
+    refreshToken,
+    refreshExpiresIn,
+  });
+  return { accessTokenCookie, refreshTokenCookie };
 };
 
-export const fetchRefreshAuth = async (request: Request) => {
+const getAccessTokenFromRequest = (request: Request): string | undefined => {
+  const cookieHeader = request.headers.get('cookie');
+  const accessTokenRegex = new RegExp(`${authAccessTokenName}=([^;]+)`);
+  return cookieHeader?.match(accessTokenRegex)?.[1];
+};
+
+const getRefreshTokenFromRequest = (request: Request): string | undefined => {
+  const cookieHeader = request.headers.get('cookie');
+  const refreshTokenRegex = new RegExp(`${authRefreshTokenName}=([^;]+)`);
+  return cookieHeader?.match(refreshTokenRegex)?.[1];
+};
+
+const redirectToLogin = (request: Request) => {
+  const url = new URL(request.url);
+  const redirectTo = url.pathname + url.search;
+  throw redirect(`/auth/init?redirectTo=${encodeURIComponent(redirectTo)}`);
+};
+
+const fetchRefreshAuth = async (request: Request) => {
   const refreshToken = getRefreshTokenFromRequest(request);
 
   const res = await fetch(refreshAuthUrl, {
@@ -56,91 +145,17 @@ export const fetchRefreshAuth = async (request: Request) => {
   return res;
 };
 
-const getAccessTokenFromRequest = (request: Request): string | undefined => {
-  const cookieHeader = request.headers.get('cookie');
-  const accessTokenRegex = new RegExp(`${authAccessTokenName}=([^;]+)`);
-  return cookieHeader?.match(accessTokenRegex)?.[1];
-};
-
-const getRefreshTokenFromRequest = (request: Request): string | undefined => {
-  const cookieHeader = request.headers.get('cookie');
-  const refreshTokenRegex = new RegExp(`${authRefreshTokenName}=([^;]+)`);
-  return cookieHeader?.match(refreshTokenRegex)?.[1];
-};
-
-interface RequestWithAuthResponse<T> {
-  body: T;
-  headers?: HeadersInit;
-  accessToken: string;
-}
-
-export async function requestWithAuth<T>(
-  request: Request,
-  apiCall: (accessToken: string) => Promise<T>,
-  accessTokenOverride?: string, // allow passing a refreshed token from a previous call
-): Promise<RequestWithAuthResponse<T>> {
-  // TODO might be able to drop the override, not sure yet
-  const accessToken = accessTokenOverride || getAccessTokenFromRequest(request);
-  const refreshToken = getRefreshTokenFromRequest(request);
-  if (!refreshToken) {
-    const url = new URL(request.url);
-    const redirectTo = url.pathname + url.search;
-    throw redirect(`/auth/init?redirectTo=${encodeURIComponent(redirectTo)}`);
-  }
-
-  console.log(`REFRESH HELPER: first accessToken:${accessToken}`);
-
-  if (typeof accessToken !== 'undefined') {
-    try {
-      const body = await apiCall(accessToken);
-      return { body, accessToken };
-    } catch (error) {
-      // TODO really need to create that new error type
-      if (!(error instanceof Error)) {
-        throw error;
-      }
-    }
-  }
-
-  const response = await fetchRefreshAuth(request);
-  const json = await response.json();
-  const {
-    accessToken: newAccessToken,
-    expiresIn,
-    refreshToken: newRefreshToken,
-    refreshExpiresIn,
-  } = json;
-  console.log(`REFRESH HELPER: second accessToken:${newAccessToken}`);
-  const { accessTokenCookie, refreshTokenCookie } = makeAuthCookies({
-    accessToken: newAccessToken,
-    expiresIn,
-    refreshToken: newRefreshToken,
-    refreshExpiresIn,
-  });
-  const body = await apiCall(newAccessToken);
-  return {
-    body,
-    headers: [
-      ['Set-Cookie', accessTokenCookie],
-      ['Set-Cookie', refreshTokenCookie],
-    ],
-    accessToken: newAccessToken,
-  };
-}
-
-interface MakeAuthCookiesProps {
-  accessToken: string;
-  expiresIn: number;
-  refreshToken: string;
-  refreshExpiresIn: number;
-}
-
-export const makeAuthCookies = ({
+const makeAuthCookies = ({
   accessToken,
   expiresIn,
   refreshToken,
   refreshExpiresIn,
-}: MakeAuthCookiesProps) => {
+}: {
+  accessToken: string;
+  expiresIn: number;
+  refreshToken: string;
+  refreshExpiresIn: number;
+}) => {
   const accessTokenCookie = `access_token=${accessToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${expiresIn}`;
   const refreshTokenCookie = `refresh_token=${refreshToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${refreshExpiresIn}`;
   return { accessTokenCookie, refreshTokenCookie };

--- a/app/shared/auth.ts
+++ b/app/shared/auth.ts
@@ -156,6 +156,8 @@ const makeAuthCookies = ({
   refreshToken: string;
   refreshExpiresIn: number;
 }) => {
+  console.log('MAKING AUTH COOKIES');
+  console.log({ accessToken, expiresIn, refreshToken, refreshExpiresIn });
   const accessTokenCookie = `access_token=${accessToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${expiresIn}`;
   const refreshTokenCookie = `refresh_token=${refreshToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${refreshExpiresIn}`;
   return { accessTokenCookie, refreshTokenCookie };

--- a/app/shared/auth.ts
+++ b/app/shared/auth.ts
@@ -156,8 +156,6 @@ const makeAuthCookies = ({
   refreshToken: string;
   refreshExpiresIn: number;
 }) => {
-  console.log('MAKING AUTH COOKIES');
-  console.log({ accessToken, expiresIn, refreshToken, refreshExpiresIn });
   const accessTokenCookie = `access_token=${accessToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${expiresIn}`;
   const refreshTokenCookie = `refresh_token=${refreshToken}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${refreshExpiresIn}`;
   return { accessTokenCookie, refreshTokenCookie };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default tseslint.config(
     rules: {
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      '@typescript-eslint/no-unused-vars': 'warn',
     },
   },
 );


### PR DESCRIPTION
- receive auth info from backend in response body instead of cookies
- set cookies when returning requests from BFF server to client
- create helper utils to make auth management "hands off" in the future
- move some env to deployed env
