### PR TITLE
move api-types from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@react-router/node": "^7.7.1",
     "@react-router/serve": "^7.7.1",
+    "@seanboose/personal-website-api-types": "1.0.12",
     "isbot": "^5.1.27",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -24,7 +25,6 @@
   "devDependencies": {
     "@eslint/js": "^9.34.0",
     "@react-router/dev": "^7.7.1",
-    "@seanboose/personal-website-api-types": "1.0.12",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",
     "@types/react": "^19.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@react-router/serve':
         specifier: ^7.7.1
         version: 7.9.4(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
+      '@seanboose/personal-website-api-types':
+        specifier: 1.0.12
+        version: 1.0.12
       isbot:
         specifier: ^5.1.27
         version: 5.1.31
@@ -33,9 +36,6 @@ importers:
       '@react-router/dev':
         specifier: ^7.7.1
         version: 7.9.4(@react-router/serve@7.9.4(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3))(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)(vite@6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2))
-      '@seanboose/personal-website-api-types':
-        specifier: 1.0.12
-        version: 1.0.12
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.16(vite@6.4.1(@types/node@20.19.23)(jiti@2.6.1)(lightningcss@1.30.2))


### PR DESCRIPTION
adding zod schema validation made it so that the @seanboose/personal-website-api-types package is used during runtime, so it's no longer a devDependency.